### PR TITLE
Node.js v16 no longer supported

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Node.js version 16 has reached its end of life and is no longer supported, it's important to upgrade to a supported version for security and stability.